### PR TITLE
other platforms are a thing

### DIFF
--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1,3 +1,9 @@
+if (process.platform !== 'win32') {
+  throw new TypeError(
+    `This module is not supported on platform '${process.platform}'`
+  )
+}
+
 const nativeModule = require('../../build/Release/registry.node')
 
 /**

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1,10 +1,7 @@
-if (process.platform !== 'win32') {
-  throw new TypeError(
-    `This module is not supported on platform '${process.platform}'`
-  )
-}
-
-const nativeModule = require('../../build/Release/registry.node')
+const nativeModule =
+  process.platform === 'win32'
+    ? require('../../build/Release/registry.node')
+    : null
 
 /**
  * Utility function used to achieve exhaustive type checks at compile time.
@@ -89,6 +86,11 @@ export function enumerateValues(
   key: HKEY,
   subkey: string
 ): ReadonlyArray<RegistryValue> {
+  if (!nativeModule) {
+    // this code is a no-op when the module is missing
+    return []
+  }
+
   const hkey = mapToLong(key)
 
   const result: ReadonlyArray<RegistryValue> = nativeModule.readValues(

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "bugs": {
     "url": "https://github.com/desktop/lean-mean-registry-client/issues"
   },
-  "os": ["win32"],
   "homepage": "https://github.com/desktop/lean-mean-registry-client#readme",
   "devDependencies": {
     "@types/benchmark": "^1.0.31",

--- a/test/registry-test.ts
+++ b/test/registry-test.ts
@@ -1,36 +1,38 @@
 import { expect } from 'chai'
 import { enumerateValues, HKEY } from '../lib/index'
 
-describe('enumerateValue', () => {
-  it('can read strings from the registry', () => {
-    const values = enumerateValues(
-      HKEY.HKEY_LOCAL_MACHINE,
-      'SOFTWARE\\Microsoft\\Windows\\CurrentVersion'
-    )
+if (process.platform === 'win32') {
+  describe('enumerateValue', () => {
+    it('can read strings from the registry', () => {
+      const values = enumerateValues(
+        HKEY.HKEY_LOCAL_MACHINE,
+        'SOFTWARE\\Microsoft\\Windows\\CurrentVersion'
+      )
 
-    const programFilesDir = values.find(v => v.name == 'ProgramFilesDir')
-    expect(programFilesDir!.type).equals('REG_SZ')
-    expect(programFilesDir!.data).contains('C:\\Program Files')
+      const programFilesDir = values.find(v => v.name == 'ProgramFilesDir')
+      expect(programFilesDir!.type).equals('REG_SZ')
+      expect(programFilesDir!.data).contains('C:\\Program Files')
 
-    const programFilesPath = values.find(v => v.name == 'ProgramFilesPath')
-    expect(programFilesPath!.type).equals('REG_EXPAND_SZ')
-    expect(programFilesPath!.data).equals('%ProgramFiles%')
+      const programFilesPath = values.find(v => v.name == 'ProgramFilesPath')
+      expect(programFilesPath!.type).equals('REG_EXPAND_SZ')
+      expect(programFilesPath!.data).equals('%ProgramFiles%')
+    })
+
+    it('can read numbers from the registry', () => {
+      const values = enumerateValues(
+        HKEY.HKEY_LOCAL_MACHINE,
+        'SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting'
+      )
+
+      const serviceTimeout = values.find(v => v.name == 'ServiceTimeout')
+      expect(serviceTimeout!.type).equals('REG_DWORD')
+      expect(serviceTimeout!.data).equals(60000)
+    })
+
+    it('returns empty array when key is missing', () => {
+      const values = enumerateValues(HKEY.HKEY_LOCAL_MACHINE, 'blahblahblah')
+
+      expect(values).is.empty
+    })
   })
-
-  it('can read numbers from the registry', () => {
-    const values = enumerateValues(
-      HKEY.HKEY_LOCAL_MACHINE,
-      'SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting'
-    )
-
-    const serviceTimeout = values.find(v => v.name == 'ServiceTimeout')
-    expect(serviceTimeout!.type).equals('REG_DWORD')
-    expect(serviceTimeout!.data).equals(60000)
-  })
-
-  it('returns empty array when key is missing', () => {
-    const values = enumerateValues(HKEY.HKEY_LOCAL_MACHINE, 'blahblahblah')
-
-    expect(values).is.empty
-  })
-})
+}


### PR DESCRIPTION
Using `optionalDependencies` to workaround platform issues means that the problem is just deferred to when you try and import code.

As there's not a good story about being able to conditionally import code based on your platform, let's just let people install the type declarations.

 - [x] test this installs fine on non-`win32`
 - [x] test this works fine in webpack