### PR TITLE
testing we can read values from HKEY_CURRENT_USER

### DIFF
--- a/test/registry-test.ts
+++ b/test/registry-test.ts
@@ -29,6 +29,17 @@ if (process.platform === 'win32') {
       expect(serviceTimeout!.data).equals(60000)
     })
 
+    it('can read values from HKCU', () => {
+      const values = enumerateValues(
+        HKEY.HKEY_CURRENT_USER,
+        'SOFTWARE\\Microsoft\\Windows\\DWM'
+      )
+
+      const composition = values.find(v => v.name == 'Composition')
+      expect(composition!.type).equals('REG_DWORD')
+      expect(composition!.data).equals(1)
+    })
+
     it('returns empty array when key is missing', () => {
       const values = enumerateValues(HKEY.HKEY_LOCAL_MACHINE, 'blahblahblah')
 


### PR DESCRIPTION
See discussion about trusting the arguments passed to `ReadValues` from JS: https://github.com/desktop/registry-js/pull/22#issuecomment-349178554