### PR TITLE
Correct the use of unique_ptr with array

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -73,7 +73,7 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
 
   auto results = New<v8::Array>(cValues);
 
-  std::unique_ptr<BYTE> buffer(new BYTE[cbMaxValueData]);
+  auto buffer = std::make_unique<BYTE[]>(cbMaxValueData);
   for (DWORD i = 0, retCode = ERROR_SUCCESS; i < cValues; i++)
   {
     cchValue = MAX_VALUE_NAME;


### PR DESCRIPTION
`std::unique_ptr` was passed a `BYTE[]` array but declared as `std::unique_ptr<BYTE>`, which will result in it using the wrong deleter.

Changed to use `std::make_unique` which is a bit simpler.