### PR TITLE
refine setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 ## A simple and opinionated library for working with the Windows registry
 
-```shellsession
-$ npm install --save registry-js
-# or
-$ yarn add registry-js
-```
-
 ## Goals
 
 * zero dependencies
@@ -17,6 +11,14 @@ $ yarn add registry-js
 
 **Note:** This is currently in preview, with support for features that GitHub
 Desktop and Atom require.
+
+## Install 
+
+```shellsession
+$ npm install --save registry-js
+# or
+$ yarn add registry-js
+```
 
 ## But Why?
 
@@ -42,6 +44,9 @@ See the documentation under the
 [`docs`](https://github.com/desktop/registry-js/tree/master/docs) folder.
 
 ## Contributing
+
+Read the [Setup](https://github.com/desktop/registry-js/blob/master/docs/index.md#setup)
+section to ensure your development environment is setup for what you need.
 
 This project isn't about implementing a 1-1 replication of the Windows registry
 API, but implementing just enough for whatever usages there are in the wild.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,9 +12,20 @@ $ cd registry-js
 $ yarn
 ```
 
-If you encounter issues with building, ensure you have the associated build
-tools installed (run this in an elevated command prompt):
+As this project builds a native module, you'll need these dependencies along with a recent version of Node:
 
-```shellsession
-$ npm install -g windows-build-tools
-```
+ - [Python 2.7](https://www.python.org/downloads/windows/)
+    - *Let Python install into the default suggested path (`c:\Python27`), otherwise you'll have
+      to configure node-gyp manually with the path which is annoying.*
+    - *Ensure the **Add python.exe to Path** option is selected.*
+ - One of Visual Studio 2015, Visual C++ Build Tools or Visual Studio 2017
+   - [Visual C++ Build Tools](http://go.microsoft.com/fwlink/?LinkId=691126)
+     - *Run `npm config set msvs_version 2015` to tell node to use this toolchain.*
+   - Visual Studio 2015 
+     - *Ensure you select the **Common Tools for Visual C++ 2015** feature as that is required by Node.js
+        for installing native modules.*
+     - *Run `npm config set msvs_version 2015` to tell node to use this toolchain.*
+   - [Visual Studio 2017](https://www.visualstudio.com/vs/community/)
+     - *Ensure you select the **Desktop development with C++** feature as that is required by Node.js for
+        installing native modules.*
+     - *Run `npm config set msvs_version 2017` to tell node to use this toolchain.*


### PR DESCRIPTION
The README now calls out straight to the Setup guide, which makes it more clear what you need to build the source correctly...