### PR TITLE
Æsthetic improvements and two fixes

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -12,10 +12,9 @@
 using namespace Nan;
 using namespace v8;
 
-#define MAX_KEY_LENGTH 255
-#define MAX_VALUE_NAME 16383
-
 namespace {
+
+const DWORD MAX_VALUE_NAME = 16383;
 
 v8::Local<v8::Object> CreateEntry(Isolate *isolate, LPWSTR name, LPWSTR type, LPWSTR data)
 {

--- a/src/main.cc
+++ b/src/main.cc
@@ -46,9 +46,6 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
   DWORD cchClassName = MAX_PATH;        // size of class string
   DWORD cValues, cchMaxValue, cbMaxValueData;
 
-  WCHAR achValue[MAX_VALUE_NAME];
-  DWORD cchValue = MAX_VALUE_NAME;
-
   auto retCode = RegQueryInfoKey(
     hCurrentKey,
     achClass,
@@ -74,15 +71,16 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
   auto results = New<v8::Array>(cValues);
 
   auto buffer = std::make_unique<BYTE[]>(cbMaxValueData);
-  for (DWORD i = 0, retCode = ERROR_SUCCESS; i < cValues; i++)
+  for (DWORD i = 0; i < cValues; i++)
   {
-    cchValue = MAX_VALUE_NAME;
+    auto cchValue = MAX_VALUE_NAME;
+    WCHAR achValue[MAX_VALUE_NAME];
     achValue[0] = '\0';
 
     DWORD lpType;
     DWORD cbData = cbMaxValueData;
 
-    retCode = RegEnumValue(
+    auto retCode = RegEnumValue(
       hCurrentKey,
       i,
       achValue,

--- a/src/main.cc
+++ b/src/main.cc
@@ -118,6 +118,7 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
       char errorMessage[50]; // 39 for message + 10 for int  + 1 for null
       sprintf_s(errorMessage, "RegEnumValue returned an error code: '%d'", retCode);
       Nan::ThrowError(errorMessage);
+      return New<v8::Array>(0);
     }
   }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -128,7 +128,7 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
     }
     else
     {
-      char errorMessage[50]; // 39 for message + 10 for int  + 1 for null
+      char errorMessage[50]; // 39 for message + 10 for int  + 1 for nul
       sprintf_s(errorMessage, "RegEnumValue returned an error code: '%d'", retCode);
       Nan::ThrowError(errorMessage);
       return New<v8::Array>(0);
@@ -182,7 +182,7 @@ NAN_METHOD(ReadValues)
   }
   else
   {
-    char errorMessage[46]; // 35 for message + 10 for int + 1 for null
+    char errorMessage[46]; // 35 for message + 10 for int + 1 for nul
     sprintf_s(errorMessage, "RegOpenKeyEx failed - exit code: '%d'", openKey);
     Nan::ThrowError(errorMessage);
   }

--- a/src/main.cc
+++ b/src/main.cc
@@ -104,18 +104,8 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
       }
       else if (lpType == REG_DWORD)
       {
-        // NOTE:
-        // at this point the value in buffer looks like this: '\x124242'
-        // i haven't figured out an easy way to parse this, so I'm going to make
-        // a second call because I know I can get the value out in the correct
-        // format in this way and avoid messing with strings
-        unsigned long size = 1024;
-
-        LONG nError = RegQueryValueEx(hCurrentKey, achValue, nullptr, &lpType, (LPBYTE)&cbData, &size);
-        if (ERROR_SUCCESS == nError)
-        {
-          Nan::Set(results, i, CreateEntry(isolate, achValue, TEXT("REG_DWORD"), cbData));
-        }
+        assert(cbData == sizeof(DWORD));
+        Nan::Set(results, i, CreateEntry(isolate, achValue, L"REG_DWORD", *reinterpret_cast<DWORD*>(buffer.get())));
       }
     }
     else if (retCode == ERROR_NO_MORE_ITEMS)

--- a/src/main.cc
+++ b/src/main.cc
@@ -42,14 +42,12 @@ v8::Local<v8::Object> CreateEntry(Isolate *isolate, LPWSTR name, LPWSTR type, DW
 }
 
 v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
-  WCHAR achClass[MAX_PATH] = L"";	// buffer for class name
-  DWORD cchClassName = MAX_PATH;        // size of class string
   DWORD cValues, cchMaxValue, cbMaxValueData;
 
   auto retCode = RegQueryInfoKey(
     hCurrentKey,
-    achClass,
-    &cchClassName,
+    nullptr, // classname (not needed)
+    nullptr, // classname length (not needed)
     nullptr, // reserved
     nullptr, // can ignore subkey values
     nullptr,

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,9 +1,10 @@
+// Windows.h strict mode
+#define STRICT
 #define UNICODE
 
 #include "nan.h"
 
 #include <windows.h>
-#include <tchar.h>
 
 #include <cstdio>
 #include <memory>
@@ -42,7 +43,7 @@ v8::Local<v8::Object> CreateEntry(Isolate *isolate, LPWSTR name, LPWSTR type, DW
 }
 
 v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
-  WCHAR achClass[MAX_PATH] = TEXT("");	// buffer for class name
+  WCHAR achClass[MAX_PATH] = L"";	// buffer for class name
   DWORD cchClassName = MAX_PATH;        // size of class string
   DWORD cValues, cchMaxValue, cbMaxValueData;
 
@@ -97,13 +98,13 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
       if (lpType == REG_SZ)
       {
         auto text = reinterpret_cast<LPWSTR>(buffer.get());
-        auto obj = CreateEntry(isolate, achValue, TEXT("REG_SZ"), text);
+        auto obj = CreateEntry(isolate, achValue, L"REG_SZ", text);
         Nan::Set(results, i, obj);
       }
       else if (lpType == REG_EXPAND_SZ)
       {
         auto text = reinterpret_cast<LPWSTR>(buffer.get());
-        auto obj = CreateEntry(isolate, achValue, TEXT("REG_EXPAND_SZ"), text);
+        auto obj = CreateEntry(isolate, achValue, L"REG_EXPAND_SZ", text);
         Nan::Set(results, i, obj);
       }
       else if (lpType == REG_DWORD)

--- a/src/main.cc
+++ b/src/main.cc
@@ -66,8 +66,8 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
 
   if (retCode != ERROR_SUCCESS)
   {
-    char errorMessage[49]; // 38 for message + 10 for int + 1 for null
-    std::sprintf(errorMessage, "RegQueryInfoKey failed - exit code: '%d'", retCode);
+    char errorMessage[49]; // 38 for message + 10 for int + 1 for nul
+    sprintf_s(errorMessage, "RegQueryInfoKey failed - exit code: '%d'", retCode);
     Nan::ThrowError(errorMessage);
     return New<v8::Array>(0);
   }
@@ -131,7 +131,7 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
     else
     {
       char errorMessage[50]; // 39 for message + 10 for int  + 1 for null
-      std::sprintf(errorMessage, "RegEnumValue returned an error code: '%d'", retCode);
+      sprintf_s(errorMessage, "RegEnumValue returned an error code: '%d'", retCode);
       Nan::ThrowError(errorMessage);
     }
   }
@@ -184,7 +184,7 @@ NAN_METHOD(ReadValues)
   else
   {
     char errorMessage[46]; // 35 for message + 10 for int + 1 for null
-    std::sprintf(errorMessage, "RegOpenKeyEx failed - exit code: '%d'", openKey);
+    sprintf_s(errorMessage, "RegOpenKeyEx failed - exit code: '%d'", openKey);
     Nan::ThrowError(errorMessage);
   }
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -53,15 +53,15 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
     hCurrentKey,
     achClass,
     &cchClassName,
-    NULL, // reserved
-    NULL, // can ignore subkey values
-    NULL,
-    NULL,
+    nullptr, // reserved
+    nullptr, // can ignore subkey values
+    nullptr,
+    nullptr,
     &cValues, // number of values for key
     &cchMaxValue, // longest value name
     &cbMaxValueData, // longest value data
-    NULL, // can ignore these values
-    NULL);
+    nullptr, // can ignore these values
+    nullptr);
 
   if (retCode != ERROR_SUCCESS)
   {
@@ -87,7 +87,7 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
       i,
       achValue,
       &cchValue,
-      NULL,
+      nullptr,
       &lpType,
       buffer.get(),
       &cbData);
@@ -115,7 +115,7 @@ v8::Local<v8::Array> EnumerateValues(HKEY hCurrentKey, Isolate *isolate) {
         // format in this way and avoid messing with strings
         unsigned long size = 1024;
 
-        LONG nError = RegQueryValueEx(hCurrentKey, achValue, NULL, &lpType, (LPBYTE)&cbData, &size);
+        LONG nError = RegQueryValueEx(hCurrentKey, achValue, nullptr, &lpType, (LPBYTE)&cbData, &size);
         if (ERROR_SUCCESS == nError)
         {
           Nan::Set(results, i, CreateEntry(isolate, achValue, TEXT("REG_DWORD"), cbData));


### PR DESCRIPTION
Fixes: #26, also returns once we hit an error in the loop instead of continuing.

(Mostly) stylistic changes:
- Remove a few unneeded buffers and variables
- `sprintf` → `sprintf_s`
- Simplify `DWORD` extraction code (this needs review – is it possible to store non-DWORD data in DWORD entries like you can shove anything into REG_SZ?)
- Use `nullptr`
- Junk `TCHAR` and its ilk

Needed:
- Need to add a test for dodgy non-null-terminated data, but I'm not sure the best way to actually get this _into_ the registry in the first place, since REG.EXE is going to do it correctly. Can we add adjunct C++ programs to the test code somehow?