### PR TITLE
RegOpenKeyEx needs a proper LPWSTR

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -184,12 +184,20 @@ NAN_METHOD(ReadValues)
   }
 
   auto first = reinterpret_cast<HKEY>(info[0]->IntegerValue());
-  auto second = *v8::String::Value(info[1]);
+
+  v8::String::Utf8Value subkeyArg(info[1]->ToString());
+  auto subkey = utf8ToWideChar(std::string(*subkeyArg));
+
+  if (subkey == nullptr)
+  {
+    Nan::ThrowTypeError("A string was expected for the second argument, but could not be parsed.");
+    return;
+  }
 
   HKEY hCurrentKey;
   LONG openKey = RegOpenKeyEx(
     first,
-    (LPWSTR)second,
+    subkey,
     0,
     KEY_READ | KEY_WOW64_64KEY,
     &hCurrentKey);

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,6 +16,31 @@ namespace {
 
 const DWORD MAX_VALUE_NAME = 16383;
 
+LPWSTR utf8ToWideChar(std::string utf8) {
+  int wide_char_length = MultiByteToWideChar(CP_UTF8,
+    0,
+    utf8.c_str(),
+    -1,
+    nullptr,
+    0);
+  if (wide_char_length == 0) {
+    return nullptr;
+  }
+
+  LPWSTR result = new WCHAR[wide_char_length];
+  if (MultiByteToWideChar(CP_UTF8,
+    0,
+    utf8.c_str(),
+    -1,
+    result,
+    wide_char_length) == 0) {
+      delete[] result;
+      return nullptr;
+  }
+
+  return result;
+}
+
 v8::Local<v8::Object> CreateEntry(Isolate *isolate, LPWSTR name, LPWSTR type, LPWSTR data, DWORD dataLengthBytes)
 {
   // NB: We must verify the data, since there's no guarantee that REG_SZ are stored with null terminators.


### PR DESCRIPTION
Found this when running the tests up on Windows 7 - all the tests that expect data fail.

```
$ mocha dist/test/**/*.js


  enumerateValue
    1) can read strings from the registry
    2) can read numbers from the registry
    3) can read values from HKCU
    √ returns empty array when key is missing


  1 passing (0ms)
  3 failing

  1) enumerateValue
       can read strings from the registry:
     TypeError: Cannot read property 'type' of undefined
      at Context.it (dist\test\registry-test.js:10:43)

  2) enumerateValue
       can read numbers from the registry:
     TypeError: Cannot read property 'type' of undefined
      at Context.it (dist\test\registry-test.js:19:42)

  3) enumerateValue
       can read values from HKCU:
     TypeError: Cannot read property 'type' of undefined
      at Context.it (dist\test\registry-test.js:25:39)
```

I traced this to `RegOpenKeyEx` expecting a `LPWSTR` rather than a UTF-8 string - the cast here isn't correct, and I'm not sure why this works fine on later platforms like Win10 or whatever AppVeyor is running.

 - [x] test this also works fine when running in an Electron app on Win7