### PR TITLE
add additional node versions to test matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,16 @@ platform:
 
 environment:
   matrix:
+    # previous LTS
     - nodejs_version: '8'
+    # latest LTS
     - nodejs_version: '10'
+    # Electron 3
+    - nodejs_version: '10.2.0'
+    # Electron 4
+    - nodejs_version: '10.11.0'
+    # bleeding edge
+    - nodejs_version: '11'
 
 cache:
   - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     # latest LTS
     - nodejs_version: '10'
     # Electron 3
-    - nodejs_version: '10.2.0'
+    - nodejs_version: '10.2.1'
     # Electron 4
     - nodejs_version: '10.11.0'
     # bleeding edge


### PR DESCRIPTION
This adds support for testing these versions:

 - Node 10.2.1 (basically Electron 3.x) - (10.2.0 has broken headers https://github.com/nodejs/node/issues/20921)
 - Node 10.11.0 (the basis for Electron 4.x)
 - Node 11.x (latest version)