### PR TITLE
fix: v8::Handle -> v8::Local for Node 12 compact

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -286,7 +286,7 @@ NAN_METHOD(EnumKeys) {
     RegCloseKey(hCurrentKey);
 }
 
-void Init(v8::Handle<v8::Object> exports) {
+void Init(v8::Local<v8::Object> exports) {
   Nan::SetMethod(exports, "readValues", ReadValues);
   Nan::SetMethod(exports, "enumKeys", EnumKeys);
 }


### PR DESCRIPTION
Changed V8::Handle to v8::Local for Node 12.

Ref: http://electronjs.org/blog/nodejs-native-addons-and-electron-5