### PR TITLE
disable caching node_modules for the moment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@ os: Visual Studio 2017
 platform:
   - x64
 
-cache:
-  - node_modules
-
 branches:
   only:
     - /master|^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
#71 initially failed because `yarn install --force` did not rebuild any native node modules:

```
yarn install --force
yarn install v1.13.0
[1/4] Resolving packages...
[2/4] Fetching packages...
yarn check-prettier
```

Which meant the test failed because it couldn't find the native node module we need:


```
$ jest -c jest.json
FAIL dist/test/registry-test.js
  ● Test suite failed to run
    Cannot find module '../../build/Release/registry.node' from 'registry.js'
    However, Jest was able to find:
    	'./registry.d.ts'
    	'./registry.js'
    	'./registry.js.map'
    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].
    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string
    However, Jest was able to find:
```
