### PR TITLE
add prebuild targets for Electron 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "check-prettier": "prettier --list-different lib/*.ts test/*.ts",
     "prebuild-node": "prebuild -t 8.16.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 --strip",
     "prebuild-node-ia32": "prebuild -t 8.16.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 3.0.0 -t 4.0.4 -t 5.0.0 -t 6.0.0 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 3.0.0 -t 4.0.4  -t 5.0.0 -t 6.0.0 -r electron -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 3.0.0 -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 3.0.0 -t 4.0.4  -t 5.0.0 -t 6.0.0 -t 7.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js"
   },
   "repository": {
@@ -37,7 +37,7 @@
     "@types/node": "^12.0.0",
     "benchmark": "^2.1.4",
     "jest": "^24.0.0",
-    "node-abi": "2.10.0",
+    "node-abi": "2.12.0",
     "prebuild": "^9.0.0",
     "prettier": "^1.14.2",
     "ts-node": "^8.0.1",
@@ -48,6 +48,6 @@
     "prebuild-install": "^5.2.4"
   },
   "resolutions": {
-    "**/node-abi": "2.10.0"
+    "**/node-abi": "2.12.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,10 +2830,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-abi@2.10.0, node-abi@^2.2.0, node-abi@^2.7.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.10.0.tgz#894bc6625ee042627ed9b5e9270d80bb63ef5045"
-  integrity sha512-OT0WepUvYHXdki6DU8LWhEkuo3M44i2paWBYtH9qXtPb9YiKlYEKa5WUII20XEcOv7UJPzfB0kZfPZdW46zdkw==
+node-abi@2.12.0, node-abi@^2.2.0, node-abi@^2.7.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.12.0.tgz#40e9cfabdda1837863fa825e7dfa0b15686adf6f"
+  integrity sha512-VhPBXCIcvmo/5K8HPmnWJyyhvgKxnHTUMXR/XwGHV68+wrgkzST4UmQrY/XszSWA5dtnXpNp528zkcyJ/pzVcw==
   dependencies:
     semver "^5.4.1"
 


### PR DESCRIPTION
This PR adds prebuild targets for Electron 7 and updates the node-abi dependency to latest version.
Refers to #170 