### PR TITLE
Drop old versions of node and electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "benchmark": "ts-node benchmarks/reg.ts",
     "prettier": "prettier --write lib/*.ts test/*.ts",
     "check-prettier": "prettier --list-different lib/*.ts test/*.ts",
-    "prebuild-node": "prebuild -t 8.16.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 14.8.0 --strip",
-    "prebuild-node-ia32": "prebuild -t 8.16.0 -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 14.8.0 -a ia32 --strip",
-    "prebuild-electron": "prebuild -t 3.0.0 -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -r electron --strip",
-    "prebuild-electron-ia32": "prebuild -t 3.0.0 -t 4.0.4  -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -r electron -a ia32 --strip",
+    "prebuild-node": "prebuild -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 14.8.0 --strip",
+    "prebuild-node-ia32": "prebuild -t 10.11.0 -t 11.9.0 -t 12.0.0 -t 14.8.0 -a ia32 --strip",
+    "prebuild-electron": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -r electron --strip",
+    "prebuild-electron-ia32": "prebuild -t 7.0.0 -t 8.0.0 -t 9.0.0 -r electron -a ia32 --strip",
     "upload": "node ./script/upload.js"
   },
   "repository": {


### PR DESCRIPTION
These are very old versions of node and electron, no point in us prebuilding for every version there is.