### PR TITLE
Release registry-js 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry-js",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "A simple and opinionated library for working with the Windows registry",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index.d.ts",


### PR DESCRIPTION
Preparing to release registry-js 1.10.0.

See diff: https://github.com/desktop/registry-js/compare/v1.9.0...3ed2fde62c2fc98d40d7b3c3fdd7c2bb200573a3

Included PRs:
 - #175, #179 automated bumps of sub-dependencies
 - #180 thanks @ottosson 
 - #182 thanks @pimterry
 - #184 Stop prebuilding for node 8 and electron 3, 4, 5, and 6.  
 - #183, #185, #186 upgrade typescript, prebuild, ts-node, and prettier to latest versions