### PR TITLE
Exclude unnecessary build artifacts from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 # ignore everything unrelated to the source code
 .vscode
+.prettierrc
 benchmarks/
 docs/
 lib/
@@ -12,6 +13,8 @@ tsconfig.json
 vendor/
 yarn-error.log
 *.tgz
+build
+jest.json
 
 # just include these specific artifacts
 # everything else should be compiled by the client

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 # ignore everything unrelated to the source code
 .vscode
-.prettierrc
+.prettierrc.yml
 benchmarks/
 docs/
 lib/


### PR DESCRIPTION
When publishing #187 I spotted what I thought was an excessive amount of build artifacts for a package leveraging prebuilt.

```
npm notice package: registry-js@1.10.0
npm notice === Tarball Contents ===
npm notice 1.1kB   LICENSE
npm notice 9.0kB   src/main.cc
npm notice 750B    build/Release/registry.exp
npm notice 2.4kB   build/registry.vcxproj.filters
npm notice 548B    binding.gyp
npm notice 2.5MB   build/Release/registry.ilk
npm notice 658B    dist/lib/index.js
npm notice 2.7kB   dist/test/registry-test.js
npm notice 4.4kB   dist/lib/registry.js
npm notice 47B     jest.json
npm notice 1.8kB   package.json
npm notice 217B    build/Release/obj/registry/registry.tlog/registry.lastbuildstate  
npm notice 1.8kB   build/Release/registry.lib
npm notice 128B    dist/lib/index.js.map
npm notice 2.5kB   dist/test/registry-test.js.map
npm notice 2.4kB   dist/lib/registry.js.map
npm notice 2.3kB   README.md
npm notice 529.4kB build/Release/registry.node
npm notice 786.9kB build/Release/obj/registry/main.obj
npm notice 24.6kB  build/Release/obj/registry/win_delay_load_hook.obj
npm notice 5.9MB   build/Release/registry.pdb
npm notice 853B    build/binding.sln
npm notice 666B    build/Release/obj/registry/registry.tlog/CL.3320.write.1.tlog     
npm notice 5.2kB   build/Release/obj/registry/registry.tlog/CL.command.1.tlog        
npm notice 49.9kB  build/Release/obj/registry/registry.tlog/CL.read.1.tlog
npm notice 316B    build/Release/obj/registry/registry.tlog/link-VCTIP.delete.1.tlog      
npm notice 604B    build/Release/obj/registry/registry.tlog/link-VCTIP.delete.19.tlog     
npm notice 316B    build/Release/obj/registry/registry.tlog/link-VCTIP.delete.33.tlog
npm notice 316B    build/Release/obj/registry/registry.tlog/link-VCTIP.delete.7.tlog      
npm notice 5.3kB   build/Release/obj/registry/registry.tlog/link-VCTIP.read.1.tlog        
npm notice 468B    build/Release/obj/registry/registry.tlog/link-VCTIP.read.14.tlog       
npm notice 150B    build/Release/obj/registry/registry.tlog/link-VCTIP.read.15.tlog  
npm notice 164B    build/Release/obj/registry/registry.tlog/link-VCTIP.read.19.tlog       
npm notice 28B     build/Release/obj/registry/registry.tlog/link-VCTIP.read.20.tlog       
npm notice 28B     build/Release/obj/registry/registry.tlog/link-VCTIP.read.21.tlog       
npm notice 28B     build/Release/obj/registry/registry.tlog/link-VCTIP.read.22.tlog       
npm notice 28B     build/Release/obj/registry/registry.tlog/link-VCTIP.read.33.tlog       
npm notice 3.5kB   build/Release/obj/registry/registry.tlog/link-VCTIP.read.7.tlog        
npm notice 3.1kB   build/Release/obj/registry/registry.tlog/link-VCTIP.read.9.tlog   
npm notice 346B    build/Release/obj/registry/registry.tlog/link-VCTIP.write.1.tlog  
npm notice 28B     build/Release/obj/registry/registry.tlog/link-VCTIP.write.19.tlog      
npm notice 28B     build/Release/obj/registry/registry.tlog/link-VCTIP.write.33.tlog      
npm notice 28B     build/Release/obj/registry/registry.tlog/link-VCTIP.write.7.tlog       
npm notice 1.6kB   build/Release/obj/registry/registry.tlog/link.command.1.tlog      
npm notice 4.5kB   build/Release/obj/registry/registry.tlog/link.read.1.tlog
npm notice 800B    build/Release/obj/registry/registry.tlog/link.write.1.tlog
npm notice 434B    build/Release/obj/registry/registry.tlog/registry.write.1u.tlog        
npm notice 29B     dist/lib/index.d.ts
npm notice 12B     dist/test/registry-test.d.ts
npm notice 2.0kB   dist/lib/registry.d.ts
npm notice 10.8kB  build/registry.vcxproj
npm notice 108B    .prettierrc.yml
npm notice === Tarball Details ===
npm notice name:          registry-js
npm notice version:       1.10.0
npm notice package size:  2.0 MB
npm notice unpacked size: 9.8 MB
npm notice shasum:        51e11ac6d49909dd03e0a90ff64b01e89009b285
npm notice integrity:     sha512-AhjIj3Q7iAUsp[...]+pLThjDxWTbxg==
npm notice total files:   52
```

After excluding the build directory we're down from 9.8Mb unpacked to 29.5 kB which seems much more reasonable

```
npm notice package: registry-js@1.10.0
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE
npm notice 9.0kB src/main.cc
npm notice 548B  binding.gyp
npm notice 658B  dist/lib/index.js
npm notice 2.7kB dist/test/registry-test.js    
npm notice 4.4kB dist/lib/registry.js
npm notice 1.8kB package.json
npm notice 128B  dist/lib/index.js.map
npm notice 2.5kB dist/test/registry-test.js.map
npm notice 2.4kB dist/lib/registry.js.map
npm notice 2.3kB README.md
npm notice 29B   dist/lib/index.d.ts
npm notice 12B   dist/test/registry-test.d.ts
npm notice 2.0kB dist/lib/registry.d.ts
npm notice === Tarball Details ===
npm notice name:          registry-js
npm notice version:       1.10.0
npm notice filename:      registry-js-1.10.0.tgz
npm notice package size:  8.9 kB
npm notice unpacked size: 29.5 kB
npm notice shasum:        0e4f5c4211cc7f427b13cf7e11d0741dcf2dab3b
npm notice integrity:     sha512-eP9CuyOrYeYdv[...]1llemo4RypsAA==
npm notice total files:   14
```

I see this was attempted in #45 and I'm not sure what's changed since but the latest v1.9.0 release was also pretty substantial (even larger actually which I suspect has to do with #184).

cc @ottosson FYI