### PR TITLE
Release v1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry-js",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "A simple and opinionated library for working with the Windows registry",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index.d.ts",


### PR DESCRIPTION
Preparing to release registry-js 1.11.0.

See diff: https://github.com/desktop/registry-js/compare/v1.10.0...872d903

Included PRs:
 - #188 Exclude unnecessary build artifacts from npm package