### PR TITLE
Release 1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry-js",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "A simple and opinionated library for working with the Windows registry",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index.d.ts",


### PR DESCRIPTION
Preparing to release registry-js 1.12.0.

See diff: https://github.com/desktop/registry-js/compare/v1.11.0...ed3ede0

This PR bumps dependencies such that consumers of this package can avoid automated vulnerability alerts. There is no difference in functionality between 1.11.0 and this version.

Included PRs:
 - #191 Bump handlebars
 - #192 Bump prebuild-install and nan dependencies
 - #193 Bump jest and ts-node
 - #194 Bump kind-of and bl