### PR TITLE
Skip build on platforms other than Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index.d.ts",
   "scripts": {
-    "install": "prebuild-install || node-gyp rebuild",
+    "install": "node skip.js || prebuild-install || node-gyp rebuild",
     "build": "tsc",
     "pretest": "yarn build",
     "test": "jest -c jest.json",

--- a/skip.js
+++ b/skip.js
@@ -1,0 +1,5 @@
+const platform = process.env.npm_config_platform || process.platform
+
+if (platform === 'win32') {
+  process.exit(1)
+}


### PR DESCRIPTION
Necessary when dependents are cross-platform. The alternatives are setting "os" in `package.json` (which only works for yarn,
not npm), using `optionalDependencies` in dependents (which would unfortunately ignore legit build failures), or building a dummy native addon (which is the current approach but it requires users to have an otherwise unnecessary build toolchain).

This simple solution works for both yarn and npm. Also accounts for cross-compiling scenarios (when `process.platform` does not match the target platform) by checking `env.npm_config_platform`.