### PR TITLE
Add support for REG_EXPAND_SZ type

### DIFF
--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -173,6 +173,7 @@ export function setValue(
 
   if (
     valueType != RegistryValueType.REG_SZ &&
+    valueType != RegistryValueType.REG_EXPAND_SZ &&
     valueType != RegistryValueType.REG_DWORD
   ) {
     // not implemented yet

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "registry-js",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry-js",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "A simple and opinionated library for working with the Windows registry",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index.d.ts",

--- a/src/main.cc
+++ b/src/main.cc
@@ -426,7 +426,7 @@ Napi::Value SetValue(const Napi::CallbackInfo& info)
   {
     long setValue = ERROR_INVALID_HANDLE;
 
-    if (wcscmp(valueType, L"REG_SZ") == 0)
+    if (wcscmp(valueType, L"REG_SZ") == 0 || wcscmp(valueType, L"REG_EXPAND_SZ") == 0)
     {
       std::string typeArg = info[4].As<Napi::String>();
       auto valueData = utf8ToWideChar(typeArg);
@@ -436,11 +436,12 @@ Napi::Value SetValue(const Napi::CallbackInfo& info)
         return env.Undefined();
       }
       int datalength = static_cast<int>(wcslen(valueData) * sizeof(valueData[0]));
+      DWORD regType = wcscmp(valueType, L"REG_SZ") == 0 ? REG_SZ : REG_EXPAND_SZ;
       setValue = RegSetValueEx(
           hOpenKey,
           valueName,
           0,
-          REG_SZ,
+          regType,
           (const BYTE *)valueData,
           datalength);
     }

--- a/test/registry-test.ts
+++ b/test/registry-test.ts
@@ -75,7 +75,7 @@ if (process.platform === 'win32') {
         HKEY.HKEY_CURRENT_USER,
         'SOFTWARE\\Microsoft\\Windows\\CurrentVersion',
         'ValueTest',
-        RegistryValueType.REG_EXPAND_SZ,
+        RegistryValueType.REG_MULTI_SZ,
         'Value'
       )
       expect(result).toBeFalsy()
@@ -129,6 +129,33 @@ if (process.platform === 'win32') {
       const programFilesDir = values.find(v => v.name == 'ValueTestSz')
       expect(programFilesDir!.type).toBe('REG_SZ')
       expect(programFilesDir!.data).toBe('Value 123 ! test@test.com (456)')
+    })
+
+    it('can set REG_EXPAND_SZ value for a registry key', () => {
+      let result = false
+      try {
+        result = setValue(
+          HKEY.HKEY_CURRENT_USER,
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion',
+          'ValueTestExpandSz',
+          RegistryValueType.REG_EXPAND_SZ,
+          'Value 123 ! test@test.com (456);%NVM_HOME%;%NVM_SYMLINK%'
+        )
+      } catch (e) {
+        console.log(e)
+      }
+      expect(result).toBeTruthy()
+
+      const values = enumerateValues(
+        HKEY.HKEY_CURRENT_USER,
+        'SOFTWARE\\Microsoft\\Windows\\CurrentVersion'
+      )
+
+      const value = values.find(v => v.name == 'ValueTestExpandSz')
+      expect(value!.type).toBe('REG_EXPAND_SZ')
+      expect(value!.data).toBe(
+        'Value 123 ! test@test.com (456);%NVM_HOME%;%NVM_SYMLINK%'
+      )
     })
   })
 


### PR DESCRIPTION
In order to implement https://github.com/desktop/desktop/pull/18244, support for writing `REG_EXPAND_SZ` values was needed.

After some investigation, it looks like it's just a string value that might contain expandable variables, so I have reused the logic to set `REG_SZ` values.