### PR TITLE
Add shell option to spawnSync in upload script

### DIFF
--- a/script/upload.js
+++ b/script/upload.js
@@ -10,5 +10,5 @@ spawnSync(
       (process.platform === 'win32' ? '.cmd' : '')
   ),
   ['--upload-all', process.env.GITHUB_AUTH_TOKEN],
-  { stdio: 'inherit' }
+  { stdio: 'inherit', shell: true }
 )


### PR DESCRIPTION
Closes #283

For some reason, the lack of `shell: true` made the prebuild script fail to run (not sure why now and not in previous releases though 🤷 )