### PR TITLE
Replace prebuild upload with gh release create for immutable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: windows-2022
     permissions:
-      contents: read
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +46,7 @@ jobs:
         run: npm run prebuild-napi-ia32
       - name: Publish
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        run: yarn upload
+        run: |
+          gh release create ${{ github.ref_name }} prebuilds/*.tar.gz --generate-notes --draft
         env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,12 +8,17 @@ of the form `releases/x.x.x`
 After running commands in 'Publishing to NPM', the release branch should be
 pushed. Now, you need to get it reviewed and merged.
 
-After that, don't forget publish the release on the repo.
+After merging, pushing the tag (via `npm publish`) will trigger CI which creates
+a **draft** GitHub release with prebuilt binaries attached. To finalize:
 
 - Go to https://github.com/desktop/registry-js/releases
-- Click click `Draft a New Release`
-- Fill in form
+- Find the draft release created by CI
+- Review that all assets are present (3 `.tar.gz` files)
 - Hit `Publish release`
+
+> **Note:** Publishing the release makes it immutable — assets and the tag can no
+> longer be modified. If something is wrong, delete the draft and cut a new
+> version.
 
 ## Publishing to NPM
 


### PR DESCRIPTION
## Summary

Replaces the `prebuild --upload-all` release mechanism with `gh release create --draft` to support [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).

## Problem

`prebuild` creates a **non-draft published release** and then uploads assets in separate API calls. With immutable releases enabled, those uploads are rejected (`422: Cannot upload assets to an immutable release`). This is a [known open issue](https://github.com/prebuild/prebuild/issues/302) in prebuild.

## Solution

- Replace `yarn upload` with `gh release create ${{ github.ref_name }} prebuilds/*.tar.gz --generate-notes --draft`
- Change permissions from `contents: read` to `contents: write` (required for `gh release create`)
- CI now creates a **draft** release with all assets attached atomically
- A human reviews and publishes the draft, which locks it as immutable

## Validation

Tested end-to-end on a fork (`tidy-dev/registry-js`) with immutable releases enabled:
- ❌ Old `prebuild` flow fails: https://github.com/tidy-dev/registry-js/actions/runs/28388707501
- ✅ New `gh release create` flow succeeds: https://github.com/tidy-dev/registry-js/actions/runs/28390034974

## Related

- https://github.com/github/gh-cli-and-desktop/issues/208